### PR TITLE
Merge CFG80211OS_ScanEnd() into CFG80211_ScanEnd()

### DIFF
--- a/common/rtusb_io.c
+++ b/common/rtusb_io.c
@@ -989,7 +989,7 @@ static int RegHint11DHdlr(IN struct rtmp_adapter *pAd, struct rtmp_queue_elem *C
 
 static int RT_Mac80211_ScanEnd(IN struct rtmp_adapter *pAd, struct rtmp_queue_elem *CMDQelmt)
 {
-	RT_CFG80211_SCAN_END(pAd, false);
+	CFG80211_ScanEnd(pAd, false);
 	return NDIS_STATUS_SUCCESS;
 }
 

--- a/include/cfg80211extr.h
+++ b/include/cfg80211extr.h
@@ -47,9 +47,6 @@
 	CFG80211_Scaning((void *)__pAd, __BssIdx, __ChanId, __pFrame,			\
 						__FrameLen, __RSSI);
 
-#define RT_CFG80211_SCAN_END(__pAd, __FlgIsAborted)							\
-	CFG80211_ScanEnd((void *)__pAd, __FlgIsAborted);
-
 #define RT_CFG80211_REINIT(__pAd)											\
 	CFG80211_SupBandReInit((void *)__pAd);									\
 
@@ -142,9 +139,7 @@ void CFG80211_RegHint11D(
 	IN u8 				*pCountryIe,
 	IN ULONG					CountryIeLen);
 
-void CFG80211_ScanEnd(
-	IN void 					*pAdCB,
-	IN bool 				FlgIsAborted);
+void CFG80211_ScanEnd(struct rtmp_adapter *rtmp, bool is_aborted);
 
 void CFG80211_ConnectResultInform(
 	IN void 					*pAdCB,

--- a/include/rt_os_util.h
+++ b/include/rt_os_util.h
@@ -843,10 +843,6 @@ void CFG80211OS_Scaning(
 	IN bool 				FlgIsNMode,
 	IN u8					BW);
 
-void CFG80211OS_ScanEnd(
-	IN void 					*pCB,
-	IN bool 				FlgIsAborted);
-
 void CFG80211OS_ConnectResultInform(
 	IN void 					*pCB,
 	IN u8 				*pBSSID,

--- a/os/linux/rt_linux.c
+++ b/os/linux/rt_linux.c
@@ -2438,47 +2438,6 @@ void CFG80211OS_Scaning(
 #endif /* CONFIG_STA_SUPPORT */
 }
 
-
-/*
-========================================================================
-Routine Description:
-	Inform us that scan ends.
-
-Arguments:
-	pAdCB			- WLAN control block pointer
-	FlgIsAborted	- 1: scan is aborted
-
-Return Value:
-	NONE
-
-Note:
-========================================================================
-*/
-void CFG80211OS_ScanEnd(
-	IN void *pCB,
-	IN bool FlgIsAborted)
-{
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0))
-	struct cfg80211_scan_info info = {
-		.aborted = FlgIsAborted,
-	};
-#endif
-
-#ifdef CONFIG_STA_SUPPORT
-	CFG80211_CB *pCfg80211_CB = (CFG80211_CB *)pCB;
-
-
-	CFG80211DBG(RT_DEBUG_ERROR, ("80211> cfg80211_scan_done\n"));
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0))
-	cfg80211_scan_done(pCfg80211_CB->pCfg80211_ScanReq, &info);
-#else
-	cfg80211_scan_done(pCfg80211_CB->pCfg80211_ScanReq, FlgIsAborted);
-#endif
-
-#endif /* CONFIG_STA_SUPPORT */
-}
-
-
 /*
 ========================================================================
 Routine Description:


### PR DESCRIPTION
Me again!

I realize some of this code is going to get killed,; however, I still think this refactoring is useful because it prevents others from wasting their time trying to track down page faults in CFG80211_ScanEnd(). Didn't find the issue, but made the code far more readable...