### PR TITLE
Add support for ARM6vl (RaspberryPi)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ ifeq ($(PLATFORM),PC)
 KSRC = /lib/modules/$(shell uname -r)/build
 CROSS_COMPILE =
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
-SUBARCH := $(shell uname -m | sed -e s/i.86/i386/)
+SUBARCH := $(shell uname -m | sed -e s/i.86/i386/ -e s/armv6l/arm/)
 ARCH ?= $(SUBARCH)
 endif
 


### PR DESCRIPTION
This patch allow the build of the driver on ARMv6 (Raspberry Pi 1 A(+), B(+), Zero).

```
uname -a
Linux raspi 4.9.35-1-ARCH #1 SMP Sat Jul 1 02:05:16 UTC 2017 armv6l GNU/Linux
```
